### PR TITLE
Allow for optionally passing through type of response data

### DIFF
--- a/src/configure.ts
+++ b/src/configure.ts
@@ -1,7 +1,7 @@
 import {Configuration} from './types';
 import {identity, consumer} from './util';
 
-// this is the singleton shared confiiguration the library uses to generate instances
+// this is the singleton shared configuration the library uses to generate instances
 export const sharedConfig: Configuration = {};
 
 export default (config: Configuration): void => {

--- a/src/http.ts
+++ b/src/http.ts
@@ -30,31 +30,35 @@ export const createAxiosInstance = (url: string): AxiosInstance => {
 };
 
 // utility functions
-export const request = (
+export const request = <T = any>(
   url: string,
   configure: ConfigureInstanceRequest = identity,
-): AxiosPromise => createAxiosInstance(url)(configure({}));
+): AxiosPromise<T> => createAxiosInstance(url)(configure({}));
 
-export const get = (url: string, configure: ConfigureInstanceRequest = identity): AxiosPromise =>
-  createAxiosInstance(url).get(url, configure({}));
-
-export const post = (
+export const get = <T = any>(
   url: string,
-  data: any,
   configure: ConfigureInstanceRequest = identity,
-): AxiosPromise => createAxiosInstance(url).post(url, data, configure({}));
+): AxiosPromise<T> => createAxiosInstance(url).get(url, configure({}));
 
-export const patch = (
+export const post = <T = any>(
   url: string,
   data: any,
   configure: ConfigureInstanceRequest = identity,
-): AxiosPromise => createAxiosInstance(url).patch(url, data, configure({}));
+): AxiosPromise<T> => createAxiosInstance(url).post(url, data, configure({}));
 
-export const put = (
+export const patch = <T = any>(
   url: string,
   data: any,
   configure: ConfigureInstanceRequest = identity,
-): AxiosPromise => createAxiosInstance(url).put(url, data, configure({}));
+): AxiosPromise<T> => createAxiosInstance(url).patch(url, data, configure({}));
 
-export const del = (url: string, configure: ConfigureInstanceRequest = identity): AxiosPromise =>
-  createAxiosInstance(url).delete(url, configure({}));
+export const put = <T = any>(
+  url: string,
+  data: any,
+  configure: ConfigureInstanceRequest = identity,
+): AxiosPromise<T> => createAxiosInstance(url).put(url, data, configure({}));
+
+export const del = <T = any>(
+  url: string,
+  configure: ConfigureInstanceRequest = identity,
+): AxiosPromise<T> => createAxiosInstance(url).delete(url, configure({}));

--- a/yarn.lock
+++ b/yarn.lock
@@ -35,7 +35,7 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.4.tgz#38fd73ddfd9b55abb1e1b2ed578cb55bd7b7d339"
   integrity sha512-8+KAKzEvSUdeo+kmqnKrqgeE+LcA0tjYWFY7RPProVYwnqDjukzO+3b6dLD56rYX5TdWejnEOLJYOIeh4CXKuA==
 
-"@types/node@^13.7.6":
+"@types/node@^13.7.7":
   version "13.7.7"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-13.7.7.tgz#1628e6461ba8cc9b53196dfeaeec7b07fa6eea99"
   integrity sha512-Uo4chgKbnPNlxQwoFmYIwctkQVkMMmsAoGGU4JKwLuvBefF0pCq4FybNSnfkfRCpC7ZW7kttcC/TrRtAJsvGtg==


### PR DESCRIPTION
This allows for passing a type through to the AxiosPromise to specify the type of the returned data so that you can interact with a strongly typed data property on the response object. T = any means that it will default to any unless you specify a type.